### PR TITLE
Update Notepad++ highlighting for RGBDS v0.5.0

### DIFF
--- a/GBz80.xml
+++ b/GBz80.xml
@@ -1,19 +1,19 @@
 <NotepadPlus>
-    <UserLang name="GBz80" ext="asm inc" udlVersion="2.1">
+    <UserLang name="GBz80" ext="asm inc z80" udlVersion="2.1">
         <Settings>
-            <Global caseIgnored="no" allowFoldOfComments="no" foldCompact="no" forcePureLC="0" decimalSeparator="0" />
+            <Global caseIgnored="yes" allowFoldOfComments="no" foldCompact="no" forcePureLC="0" decimalSeparator="0" />
             <Prefix Keywords1="no" Keywords2="no" Keywords3="no" Keywords4="no" Keywords5="no" Keywords6="no" Keywords7="no" Keywords8="no" />
         </Settings>
         <KeywordLists>
-            <Keywords name="Comments">00; 01 02 03 04</Keywords>
-            <Keywords name="Numbers, prefix1">%</Keywords>
-            <Keywords name="Numbers, prefix2">$ 0x</Keywords>
-            <Keywords name="Numbers, extras1">A B C D E F a b c d e f</Keywords>
+            <Keywords name="Comments">00; 01 02 03/* 04*/</Keywords>
+            <Keywords name="Numbers, prefix1"></Keywords>
+            <Keywords name="Numbers, prefix2">$ % &amp; `</Keywords>
+            <Keywords name="Numbers, extras1">_ A B C D E F a b c d e f</Keywords>
             <Keywords name="Numbers, extras2"></Keywords>
-            <Keywords name="Numbers, suffix1">h</Keywords>
+            <Keywords name="Numbers, suffix1"></Keywords>
             <Keywords name="Numbers, suffix2"></Keywords>
             <Keywords name="Numbers, range"></Keywords>
-            <Keywords name="Operators1">, + - * / % &amp; | ^</Keywords>
+            <Keywords name="Operators1">, ( ) [ ] ** ~ + - * / % &lt;&lt; &gt;&gt; &amp; | ^ != == &lt;= &gt;= &lt; &gt; &amp;&amp; || ! = \@ \# \1 \2 \3 \4 \5 \6 \7 \8 \9</Keywords>
             <Keywords name="Operators2"></Keywords>
             <Keywords name="Folders in code1, open"></Keywords>
             <Keywords name="Folders in code1, middle"></Keywords>
@@ -24,36 +24,36 @@
             <Keywords name="Folders in comment, open"></Keywords>
             <Keywords name="Folders in comment, middle"></Keywords>
             <Keywords name="Folders in comment, close"></Keywords>
-            <Keywords name="Keywords1">add&#x000D;&#x000A;adc&#x000D;&#x000A;and&#x000D;&#x000A;bit&#x000D;&#x000A;call&#x000D;&#x000A;ccf&#x000D;&#x000A;cp&#x000D;&#x000A;cpl&#x000D;&#x000A;dec&#x000D;&#x000A;di&#x000D;&#x000A;ei&#x000D;&#x000A;halt&#x000D;&#x000A;inc&#x000D;&#x000A;jp&#x000D;&#x000A;jr&#x000D;&#x000A;ld&#x000D;&#x000A;ldd&#x000D;&#x000A;ldh&#x000D;&#x000A;ldi&#x000D;&#x000A;nop&#x000D;&#x000A;or&#x000D;&#x000A;pop&#x000D;&#x000A;push&#x000D;&#x000A;res&#x000D;&#x000A;ret&#x000D;&#x000A;reti&#x000D;&#x000A;rl&#x000D;&#x000A;rla&#x000D;&#x000A;rlc&#x000D;&#x000A;rlca&#x000D;&#x000A;rr&#x000D;&#x000A;rra&#x000D;&#x000A;rrc&#x000D;&#x000A;rrca&#x000D;&#x000A;rst&#x000D;&#x000A;sub&#x000D;&#x000A;sbc&#x000D;&#x000A;scf&#x000D;&#x000A;set&#x000D;&#x000A;sla&#x000D;&#x000A;sra&#x000D;&#x000A;srl&#x000D;&#x000A;stop&#x000D;&#x000A;swap&#x000D;&#x000A;xor</Keywords>
-            <Keywords name="Keywords2">a&#x000D;&#x000A;af&#x000D;&#x000A;b&#x000D;&#x000A;bc&#x000D;&#x000A;c&#x000D;&#x000A;d&#x000D;&#x000A;de&#x000D;&#x000A;e&#x000D;&#x000A;f&#x000D;&#x000A;h&#x000D;&#x000A;hl&#x000D;&#x000A;l&#x000D;&#x000A;sp&#x000D;&#x000A;&#x000D;&#x000A;nc&#x000D;&#x000A;nz&#x000D;&#x000A;z</Keywords>
-            <Keywords name="Keywords3">DB&#x000D;&#x000A;DW&#x000D;&#x000A;DS&#x000D;&#x000A;db&#x000D;&#x000A;dw&#x000D;&#x000A;ds&#x000D;&#x000A;&#x000D;&#x000A;BANK&#x000D;&#x000A;bank&#x000D;&#x000A;&#x000D;&#x000A;REPT&#x000D;&#x000A;ENDR&#x000D;&#x000A;rept&#x000D;&#x000A;endr&#x000D;&#x000A;&#x000D;&#x000A;IF&#x000D;&#x000A;ELIF&#x000D;&#x000A;ELSE&#x000D;&#x000A;ENDC&#x000D;&#x000A;if&#x000D;&#x000A;elif&#x000D;&#x000A;else&#x000D;&#x000A;endc&#x000D;&#x000A;&#x000D;&#x000A;MACRO&#x000D;&#x000A;ENDM&#x000D;&#x000A;macro&#x000D;&#x000A;endm&#x000D;&#x000A;&#x000D;&#x000A;EQU&#x000D;&#x000A;EQUS&#x000D;&#x000A;equ&#x000D;&#x000A;equs&#x000D;&#x000A;&#x000D;&#x000A;INCLUDE&#x000D;&#x000A;INCBIN&#x000D;&#x000A;include&#x000D;&#x000A;incbin&#x000D;&#x000A;&#x000D;&#x000A;SECTION&#x000D;&#x000A;section&#x000D;&#x000A;&#x000D;&#x000A;UNION&#x000D;&#x000A;union&#x000D;&#x000A;NEXTU&#x000D;&#x000A;nextu&#x000D;&#x000A;ENDU&#x000D;&#x000A;endu</Keywords>
-            <Keywords name="Keywords4">ROM0&#x000D;&#x000A;HOME&#x000D;&#x000A;&#x000D;&#x000A;ROMX&#x000D;&#x000A;CODE&#x000D;&#x000A;DATA&#x000D;&#x000A;&#x000D;&#x000A;VRAM&#x000D;&#x000A;&#x000D;&#x000A;WRAM0&#x000D;&#x000A;WRAMX&#x000D;&#x000A;BSS&#x000D;&#x000A;&#x000D;&#x000A;HRAM</Keywords>
-            <Keywords name="Keywords5"></Keywords>
+            <Keywords name="Keywords1">ADC ADD AND BIT CALL CCF CPL CP DAA DEC DI EI HALT INC JP JR LD LDI LDD LDIO LDH NOP OR POP PUSH RES RETI RET RLCA RLC RLA RL RRC RRCA RRA RR RST SBC SCF SET SLA SRA SRL STOP SUB SWAP XOR</Keywords>
+            <Keywords name="Keywords2">AF BC DE HL SP HLD HLI A B C D E H L NZ Z NC</Keywords>
+            <Keywords name="Keywords3">DEF FRAGMENT BANK ALIGN ROUND CEIL FLOOR DIV MUL POW LOG SIN COS TAN ASIN ACOS ATAN ATAN2 HIGH LOW ISCONST STRCMP STRIN STRRIN STRSUB STRLEN STRCAT STRUPR STRLWR STRRPL STRFMT INCLUDE PRINT PRINTLN PRINTT PRINTI PRINTV PRINTF EXPORT DS DB DW DL SECTION PURGE RSRESET RSSET INCBIN CHARMAP NEWCHARMAP SETCHARMAP PUSHC POPC FAIL WARN FATAL ASSERT STATIC_ASSERT MACRO ENDM SHIFT REPT FOR ENDR BREAK LOAD ENDL IF ELSE ELIF ENDC UNION NEXTU ENDU RB RW RL EQU EQUS REDEF SET PUSHS POPS PUSHO POPO OPT</Keywords>
+            <Keywords name="Keywords4">WRAM0 VRAM ROMX ROM0 HRAM WRAMX SRAM OAM</Keywords>
+            <Keywords name="Keywords5">@ _RS _NARG __LINE__ __FILE__ __DATE__ __TIME__ __ISO_8601_LOCAL__ __ISO_8601_UTC__ __UTC_YEAR__ __UTC_MONTH__ __UTC_DAY__ __UTC_HOUR__ __UTC_MINUTE__ __UTC_SECOND__ __RGBDS_MAJOR__ __RGBDS_MINOR__ __RGBDS_PATCH__ __RGBDS_RC__ __RGBDS_VERSION__</Keywords>
             <Keywords name="Keywords6"></Keywords>
             <Keywords name="Keywords7"></Keywords>
             <Keywords name="Keywords8"></Keywords>
-            <Keywords name="Delimiters">00( 01 02) 03[ 04 05] 06&quot; 07\ 08&quot; 09 10 11 12 13 14 15 16 17 18 19 20 21 22 23</Keywords>
+            <Keywords name="Delimiters">00&quot;&quot;&quot; 01\ 02&quot;&quot;&quot; 03&quot; 04\ 05&quot; 06{ 07 08} 09 10 11 12 13 14 15 16 17 18 19 20 21 22 23</Keywords>
         </KeywordLists>
         <Styles>
             <WordsStyle name="DEFAULT" fgColor="000000" bgColor="FFFFFF" fontName="" fontStyle="0" nesting="0" />
-            <WordsStyle name="COMMENTS" fgColor="000000" bgColor="FFFFFF" fontName="" fontStyle="0" nesting="0" />
+            <WordsStyle name="COMMENTS" fgColor="008000" bgColor="FFFFFF" fontName="" fontStyle="0" nesting="0" />
             <WordsStyle name="LINE COMMENTS" fgColor="008000" bgColor="FFFFFF" fontName="" fontStyle="0" nesting="0" />
-            <WordsStyle name="NUMBERS" fgColor="FF8040" bgColor="FFFFFF" fontName="" fontStyle="0" nesting="0" />
+            <WordsStyle name="NUMBERS" fgColor="FF8000" bgColor="FFFFFF" fontName="" fontStyle="0" nesting="0" />
             <WordsStyle name="KEYWORDS1" fgColor="0000FF" bgColor="FFFFFF" fontName="" fontStyle="1" nesting="0" />
             <WordsStyle name="KEYWORDS2" fgColor="808080" bgColor="FFFFFF" fontName="" fontStyle="1" nesting="0" />
             <WordsStyle name="KEYWORDS3" fgColor="0080FF" bgColor="FFFFFF" fontName="" fontStyle="0" nesting="0" />
             <WordsStyle name="KEYWORDS4" fgColor="000000" bgColor="FFFFFF" fontName="" fontStyle="1" nesting="0" />
-            <WordsStyle name="KEYWORDS5" fgColor="000000" bgColor="FFFFFF" fontName="" fontStyle="0" nesting="0" />
+            <WordsStyle name="KEYWORDS5" fgColor="5B00B7" bgColor="FFFFFF" fontName="" fontStyle="0" nesting="0" />
             <WordsStyle name="KEYWORDS6" fgColor="000000" bgColor="FFFFFF" fontName="" fontStyle="0" nesting="0" />
             <WordsStyle name="KEYWORDS7" fgColor="000000" bgColor="FFFFFF" fontName="" fontStyle="0" nesting="0" />
             <WordsStyle name="KEYWORDS8" fgColor="000000" bgColor="FFFFFF" fontName="" fontStyle="0" nesting="0" />
-            <WordsStyle name="OPERATORS" fgColor="000000" bgColor="FFFFFF" fontName="" fontStyle="0" nesting="0" />
+            <WordsStyle name="OPERATORS" fgColor="000080" bgColor="FFFFFF" fontName="" fontStyle="1" nesting="0" />
             <WordsStyle name="FOLDER IN CODE1" fgColor="000000" bgColor="FFFFFF" fontName="" fontStyle="0" nesting="0" />
             <WordsStyle name="FOLDER IN CODE2" fgColor="000000" bgColor="FFFFFF" fontName="" fontStyle="0" nesting="0" />
             <WordsStyle name="FOLDER IN COMMENT" fgColor="000000" bgColor="FFFFFF" fontName="" fontStyle="0" nesting="0" />
-            <WordsStyle name="DELIMITERS1" fgColor="000000" bgColor="FFFFFF" fontName="" fontStyle="1" nesting="0" />
-            <WordsStyle name="DELIMITERS2" fgColor="000000" bgColor="FFFFFF" fontName="" fontStyle="1" nesting="0" />
-            <WordsStyle name="DELIMITERS3" fgColor="808080" bgColor="FFFFFF" fontName="" fontStyle="0" nesting="0" />
+            <WordsStyle name="DELIMITERS1" fgColor="808080" bgColor="FFFFFF" fontName="" fontStyle="0" nesting="4" />
+            <WordsStyle name="DELIMITERS2" fgColor="808080" bgColor="FFFFFF" fontName="" fontStyle="0" nesting="4" />
+            <WordsStyle name="DELIMITERS3" fgColor="000000" bgColor="FFFFFF" fontName="" fontStyle="0" nesting="4" />
             <WordsStyle name="DELIMITERS4" fgColor="000000" bgColor="FFFFFF" fontName="" fontStyle="0" nesting="0" />
             <WordsStyle name="DELIMITERS5" fgColor="000000" bgColor="FFFFFF" fontName="" fontStyle="0" nesting="0" />
             <WordsStyle name="DELIMITERS6" fgColor="000000" bgColor="FFFFFF" fontName="" fontStyle="0" nesting="0" />

--- a/GBz80.xml
+++ b/GBz80.xml
@@ -1,5 +1,5 @@
 <NotepadPlus>
-    <UserLang name="GBz80" ext="asm inc z80" udlVersion="2.1">
+    <UserLang name="RGBASM" ext="asm inc" udlVersion="2.1">
         <Settings>
             <Global caseIgnored="yes" allowFoldOfComments="no" foldCompact="no" forcePureLC="0" decimalSeparator="0" />
             <Prefix Keywords1="no" Keywords2="no" Keywords3="no" Keywords4="no" Keywords5="no" Keywords6="no" Keywords7="no" Keywords8="no" />


### PR DESCRIPTION
Added:
- New keywords and functions (e.g. `FOR`, `ASSERT`, `STRLEN`, etc.)
- Predeclared symbols, like `__DATE__`, `__RGBDS_MINOR__`, `@`, `_RS`, `_NARG`, etc.
- Special escape sequences: `\@`, `\#`, and `\1`-`\9`
- More operators (e.g. `=`, `~`, `&&`, `**`, etc.)
- Multi-line string literals
- Block comments
- Underscores in numbers (except in decimal format due to limitations of the UDL system &mdash; decimal uses no prefix or suffix)
- Symbol interpolation, highlighted black, including in string literals
- `z80` file extension

Changed:
- Parentheses and brackets are now operators instead of delimiters so that the highlighting of what is contained inside is not all the same colour
- Colours have been changed slightly to better match Notepad++'s built-in assembly highlighting
- Ignore case like rgbasm does

Removed:
- Unsupported numeric formats (`0x` prefix and `h` suffix)
- Removed keywords (e.g. `CODE`, `HOME`)

(Keywords from [lexer.c](https://github.com/gbdev/rgbds/blob/v0.5.0/src/asm/lexer.c#L107-L290))

Considering this is specifically rgbasm's syntax and the fact that there are other Game Boy assemblers around, would it make sense to call the user-defined language "RGBDS", following [sublime-RGBDS](https://github.com/ISSOtm/sublime-RGBDS)? I've left it as "GBz80" for now.