### PR TITLE
Update Notepad++ highlighting for RGBASM v0.5.1

### DIFF
--- a/GBz80.xml
+++ b/GBz80.xml
@@ -13,7 +13,7 @@
             <Keywords name="Numbers, suffix1"></Keywords>
             <Keywords name="Numbers, suffix2"></Keywords>
             <Keywords name="Numbers, range"></Keywords>
-            <Keywords name="Operators1">, ( ) [ ] ** ~ + - * / % &lt;&lt; &gt;&gt; &amp; | ^ != == &lt;= &gt;= &lt; &gt; &amp;&amp; || ! = \@ \# \1 \2 \3 \4 \5 \6 \7 \8 \9</Keywords>
+            <Keywords name="Operators1">, ( ) [ ] ** ~ + - * / % &lt;&lt; &gt;&gt; &amp; | ^ != == &lt;= &gt;= &lt; &gt; &amp;&amp; || ! = \@ \# \1 \2 \3 \4 \5 \6 \7 \8 \9 \&lt;</Keywords>
             <Keywords name="Operators2"></Keywords>
             <Keywords name="Folders in code1, open"></Keywords>
             <Keywords name="Folders in code1, middle"></Keywords>
@@ -26,7 +26,7 @@
             <Keywords name="Folders in comment, close"></Keywords>
             <Keywords name="Keywords1">ADC ADD AND BIT CALL CCF CPL CP DAA DEC DI EI HALT INC JP JR LD LDI LDD LDIO LDH NOP OR POP PUSH RES RETI RET RLCA RLC RLA RL RRC RRCA RRA RR RST SBC SCF SET SLA SRA SRL STOP SUB SWAP XOR</Keywords>
             <Keywords name="Keywords2">AF BC DE HL SP HLD HLI A B C D E H L NZ Z NC</Keywords>
-            <Keywords name="Keywords3">DEF FRAGMENT BANK ALIGN ROUND CEIL FLOOR DIV MUL POW LOG SIN COS TAN ASIN ACOS ATAN ATAN2 HIGH LOW ISCONST STRCMP STRIN STRRIN STRSUB STRLEN STRCAT STRUPR STRLWR STRRPL STRFMT INCLUDE PRINT PRINTLN PRINTT PRINTI PRINTV PRINTF EXPORT DS DB DW DL SECTION PURGE RSRESET RSSET INCBIN CHARMAP NEWCHARMAP SETCHARMAP PUSHC POPC FAIL WARN FATAL ASSERT STATIC_ASSERT MACRO ENDM SHIFT REPT FOR ENDR BREAK LOAD ENDL IF ELSE ELIF ENDC UNION NEXTU ENDU RB RW RL EQU EQUS REDEF SET PUSHS POPS PUSHO POPO OPT</Keywords>
+            <Keywords name="Keywords3">DEF FRAGMENT BANK ALIGN SIZEOF STARTOF ROUND CEIL FLOOR DIV MUL POW LOG SIN COS TAN ASIN ACOS ATAN ATAN2 HIGH LOW ISCONST STRCMP STRIN STRRIN STRSUB STRLEN STRCAT STRUPR STRLWR STRRPL STRFMT CHARLEN CHARSUB INCLUDE PRINT PRINTLN PRINTT PRINTI PRINTV PRINTF EXPORT DS DB DW DL SECTION PURGE RSRESET RSSET INCBIN CHARMAP NEWCHARMAP SETCHARMAP PUSHC POPC FAIL WARN FATAL ASSERT STATIC_ASSERT MACRO ENDM SHIFT REPT FOR ENDR BREAK LOAD ENDL IF ELSE ELIF ENDC UNION NEXTU ENDU RB RW RL EQU EQUS REDEF SET PUSHS POPS PUSHO POPO OPT</Keywords>
             <Keywords name="Keywords4">WRAM0 VRAM ROMX ROM0 HRAM WRAMX SRAM OAM</Keywords>
             <Keywords name="Keywords5">@ _RS _NARG __LINE__ __FILE__ __DATE__ __TIME__ __ISO_8601_LOCAL__ __ISO_8601_UTC__ __UTC_YEAR__ __UTC_MONTH__ __UTC_DAY__ __UTC_HOUR__ __UTC_MINUTE__ __UTC_SECOND__ __RGBDS_MAJOR__ __RGBDS_MINOR__ __RGBDS_PATCH__ __RGBDS_RC__ __RGBDS_VERSION__</Keywords>
             <Keywords name="Keywords6"></Keywords>


### PR DESCRIPTION
This is a small update to add the following, new in v0.5.1:
- `SIZEOF` and `STARTOF`
- `CHARLEN` and `CHARSUB`
- Multi-digit macro argument angle brackets (`\<`, and `>` is already in there)